### PR TITLE
Add release workflow template

### DIFF
--- a/workflow-templates/release-tag-bump-with-goreleaser.properties.json
+++ b/workflow-templates/release-tag-bump-with-goreleaser.properties.json
@@ -1,0 +1,12 @@
+{
+    "name": "Bump tags and release based on labeled PRs",
+    "description": "Workflow which consumes merged PRs with specific labels (bump:$version), pushes new tags accordingly, and runs GoReleaser if tags were updated.",
+    "iconName": "libopenstorage",
+    "categories": [
+        "Go"
+    ],
+    "filePatterns": [
+        ".goreleaser.yml$"
+    ]
+}
+

--- a/workflow-templates/release-tag-bump-with-goreleaser.yml
+++ b/workflow-templates/release-tag-bump-with-goreleaser.yml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  push:
+    # action-bumpr needs to work with pushes on master (there's no trigger for `pull_request:` merged)
+    branches:
+      - $default-branch
+
+jobs:
+  bump-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.bump.outputs.skip }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Bump version on merging Pull Requests with specific labels.
+      # (bump:major,bump:minor,bump:patch)
+      - name: Bump tag
+        id: bump        
+        uses: haya14busa/action-bumpr@v1
+
+  goreleaser:
+    needs: bump-tag
+    if: ${{ needs.bump-tag.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a workflow template which consumes labeled PRs created by a workflow like https://github.com/portworx/.github/pull/2, bumps the appropriate tags and creates a release from the default branch.

